### PR TITLE
add Send trait to WebTransportSession

### DIFF
--- a/sec-http3/src/webtransport/server.rs
+++ b/sec-http3/src/webtransport/server.rs
@@ -1,7 +1,7 @@
 //! Provides the server side WebTransport session
 
 use std::{
-    marker::PhantomData,
+    marker::{PhantomData, Send},
     pin::Pin,
     sync::Mutex,
     task::{Context, Poll},
@@ -34,8 +34,8 @@ use pin_project_lite::pin_project;
 /// Similar to [`crate::server::Connection`] it is generic over the QUIC implementation and Buffer.
 pub struct WebTransportSession<C, B>
 where
-    C: quic::Connection<B>,
-    B: Buf,
+    C: quic::Connection<B> + Send,
+    B: Buf + Send,
 {
     // See: https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-2-3
     session_id: SessionId,
@@ -47,8 +47,8 @@ where
 
 impl<C, B> WebTransportSession<C, B>
 where
-    C: quic::Connection<B>,
-    B: Buf,
+    C: quic::Connection<B> + Send,
+    B: Buf + Send,
 {
     /// Accepts a *CONNECT* request for establishing a WebTransport session.
     ///


### PR DESCRIPTION
In this pull request, I have made changes to ensure the WebTransportSession struct in our codebase is Send. The Send trait indicates that an object of this type is safe to move to another thread.

The changes include the addition of the Send trait constraint on the generic parameters C and B of WebTransportSession. This means that any types used as C or B must now also implement Send.